### PR TITLE
修改replace情况下礼物超过最大数量时显示错误bug

### DIFF
--- a/LiveSendGift/LiveGiftShowView/LiveGiftShowCustom.m
+++ b/LiveSendGift/LiveGiftShowView/LiveGiftShowCustom.m
@@ -360,6 +360,8 @@ static LiveGiftAppearMode live_appearModel = LiveGiftAppearModeLeft;
 - (void)resetView:(LiveGiftShowView *)view nowModel:(LiveGiftShowModel *)model isChangeNum:(BOOL)isChange number:(NSInteger)number{
     NSString * oldKey = [self getDictKey:view.model];
     NSString * dictKey = [self getDictKey:model];
+    
+    dispatch_cancel(view.model.animatedTimer);
     //找到时间早的那个视图 替换模型 重置数字
     view.model = model;
     if (isChange) {


### PR DESCRIPTION
当数组达到最大数量时，只要此时没有礼物number达到目标值全在动画，再增加礼物会错误，一直进行替换，因为没有关掉替换model的animatedTimer